### PR TITLE
docs: add README for OctoAcme project management docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+\# OctoAcme Project Management Docs
+
+
+
+Welcome to the OctoAcme project management documentation hub. This README provides an entry point for understanding how OctoAcme runs projects, the roles involved, key workflows, communication practices, and quality assurance expectations.
+
+
+
+OctoAcme follows a structured lifecycle: Initiation, Planning, Execution, Release, and Retrospective. Projects start with a lightweight Project One‑pager and stakeholder alignment to confirm goals, success metrics, and initial risks before detailed planning. Planning breaks work into shippable increments with defined acceptance criteria, capacity-aware estimates, and a release/milestone map that tracks dependencies.
+
+
+
+Execution uses a project board and a small-PR workflow (Backlog → Ready → In Progress → In Review → QA → Done), daily standups for immediate blockers, weekly delivery syncs for progress and risks, and sprint demos for feedback. Roles are explicit: Project Managers coordinate delivery and communications; Product Managers define outcomes and prioritize the backlog; Developers implement and test; QA validates acceptance criteria; and Stakeholders provide input and approvals. A clear escalation path and a weekly-maintained risk register help address blockers quickly.
+
+
+
+Quality assurance is embedded throughout: unit and integration tests, CI-based security scanning, E2E smoke tests for critical flows, and manual QA where required. Releases follow a deployment checklist (staging smoke tests, rollback plan, post-deploy verification) and include release notes and incident playbooks. Retrospectives capture learnings and convert them into action items that are tracked back into the backlog.
+
+
+
+\## Process Documentation
+
+\- \[Project Management Overview](octoacme-project-management-overview.md)
+
+\- \[Project Initiation Guide](octoacme-project-initiation.md)
+
+\- \[Project Planning](octoacme-project-planning.md)
+
+\- \[Execution \& Tracking](octoacme-execution-and-tracking.md)
+
+\- \[Risk Management \& Communication](octoacme-risks-and-communication.md)
+
+\- \[Release \& Deployment Guide](octoacme-release-and-deployment.md)
+
+\- \[Retrospective \& Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+
+\- \[Roles and Personas](octoacme-roles-and-personas.md)
+
+
+
+\## Contributing / Updates
+
+Use the issue template in `.github/ISSUE\_TEMPLATE/add-update-content-to-process-docs.yml` to propose additions or edits to these process documents. Link changes to the relevant issue and follow repository PR conventions when submitting updates.
+


### PR DESCRIPTION
Adds docs/README.md as a landing page summarizing OctoAcme project management processes and linking to the existing process docs. Closes #2